### PR TITLE
[TASK] Store upload_tmp_dir within data volume

### DIFF
--- a/container-files/etc/php-fpm.conf
+++ b/container-files/etc/php-fpm.conf
@@ -5,3 +5,4 @@ daemonize = no
 pid = /var/run/php-fpm.pid
 error_log = /data/logs/php-fpm-daemon.log
 log_level = warning
+upload_tmp_dir = /data/tmp


### PR DESCRIPTION
Web and ssh containers should share the same `upload_tmp_dir` folder, so it makes sense to put it inside `/data`.

Since some recent change to locking mechanism that now stores lock files in `/tmp`, that folder should be put on a volume too, otherwise Flow may get locked in Production context when flushing the cache from ssh container.
