### PR TITLE
TASK: Remove `php70-php-pecl-yaml` package until it is fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ RUN \
     php70-php-pecl-memcached \
     php70-php-pecl-uploadprogress \
     php70-php-pecl-uuid \
-    php70-php-pecl-yaml \
     php70-php-pecl-zip \
 
     `# Temporary workaround: one dependant package (http, not essential?) fails to install` \

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,6 @@ test:
     - curl -Ssi http://localhost:8080 | grep memory_limit | grep 512M
 
     # Check if we have PECL extensions installed / loaded
-    - curl -Ssi http://localhost:8080 | grep 'LibYAML Support'
     - curl -Ssi http://localhost:8080 | grep 'Redis Version'
 
     # Check if we have common dev tools working


### PR DESCRIPTION
Currently using this package gives weird segfault issues when using references in yaml.
