### PR TITLE
Auto chmod for /data/www

### DIFF
--- a/container-files/etc/supervisor.d/www-watch.conf
+++ b/container-files/etc/supervisor.d/www-watch.conf
@@ -1,0 +1,2 @@
+[program:www-watch]
+command=bash -c 'while inotifywait -q -r -e create,delete,modify,move,attrib --exclude "/\." /data/www; do chown -Rf www:www /data/www; done'


### PR DESCRIPTION
I faced a problem when I was syncing my files from my volume to /data/www and they always had the root:root owner. This little supervisor script watches all files and automatically changes the owner to www:www.

If you think this will cause any performance issues please give me some suggestion for improvement.

Best regards,
Michael
